### PR TITLE
Workaround harder

### DIFF
--- a/src/SelectableWebView.jsx
+++ b/src/SelectableWebView.jsx
@@ -10,10 +10,6 @@ export default class WebViewWrapper extends React.Component {
     };
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.isSelected !== prevProps.isSelected) this.forceUpdate();
-  }
-
   componentDidMount() {
     this.webView.addEventListener('did-start-loading', () => {
       console.log(this.props.src, 'is loading');
@@ -22,6 +18,15 @@ export default class WebViewWrapper extends React.Component {
 
     this.webView.addEventListener('did-stop-loading', () => {
       console.log(this.props.src, 'stopped loading');
+      this.setState(() => ({ isLoading: false }));
+    });
+  }
+
+  executeJavaScript(code) {
+    if (!this.webView || !this.webView.executeJavaScript) return;
+
+    this.setState(() => ({ isLoading: true }));
+    this.webView.executeJavaScript(code, () => {
       this.setState(() => ({ isLoading: false }));
     });
   }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -13,10 +13,7 @@ export default class App extends React.Component {
     if (selectedIndex !== 0) {
       const webView = this.webView0;
       const url = `http://httpbin.org/delay/${selectedIndex}`;
-
-      if (webView.webView.executeJavaScript) {
-        webView.webView.executeJavaScript(`document.location.href = '${url}'`)
-      }
+      webView.executeJavaScript(`document.location.href = '${url}'`)
     }
 
     this.setState(() => ({ selectedIndex }));

--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -11,13 +11,16 @@
 }
 
 webview {
-  width: 100%;
-  height: 100%;
   position: absolute;
 
+  width: 100%;
+  height: 100%;
   z-index: 1;
 
   &:not(.isSelected) {
+    flex: 0 1;
+    width: 0px;
+    height: 0px;
     z-index: -1;
   }
 }


### PR DESCRIPTION
This avoids the issues mentioned by:

1. Setting a size in addition to `z-index`, to avoid page bleeding
1. On `executeJavaScript` calls that would result in a navigation, set `isLoading` _before_ the call to `executeJavaScript`